### PR TITLE
Add meta.mainProgram

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,7 @@
         nix_checks_junit = craneLib.buildPackage {
           inherit cargoArtifacts src version;
           cargoExtraArgs = "--all-features --all";
+          meta.mainProgram = "nix_checks_junit";
         };
 
       in


### PR DESCRIPTION
This small change adds `meta.mainProgram` to the derivation. That way `lib.getExe` can be used to find the executable.

For example, to control the version of this tool I use I added it to my `flake.nix` like that:

```nix
apps.${system} = {
  nix_checks_junit = {
    type = "app";
    program = "${nix-checks-junit.packages.${system}.nix_checks_junit}/bin/nix_checks_junit";
  };
};
```

With this change I could write

```nix
apps.${system} = {
  nix_checks_junit = {
    type = "app";
    program = pkgs.lib.getExe nix-checks-junit.packages.${system}.nix_checks_junit;
  };
};
```